### PR TITLE
chore: gitignore for VS Code, remove activationEvents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,15 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# https://raw.githubusercontent.com/github/gitignore/refs/heads/main/Global/VisualStudioCode.gitignore
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+!*.code-workspace
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-  // IntelliSense を使用して利用可能な属性を学べます。
-  // 既存の属性の説明をホバーして表示します。
-  // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {

--- a/package.json
+++ b/package.json
@@ -5,15 +5,12 @@
   "version": "0.0.1",
   "publisher": "Office L",
   "engines": {
-    "vscode": "^1.74.0"
+    "vscode": "^1.75.0"
   },
   "categories": [
     "Other"
   ],
-  "activationEvents": [
-    "onCommand:status-bar-timer.startTimer",
-    "onCommand:status-bar-timer.stopTimer"
-  ],
+  "activationEvents": [],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [


### PR DESCRIPTION
- activationEvents の中は package.json から取得できるから消していいらしい
- 実運用時は vsix を作るのはリリース処理で、アーティファクト扱いにするから要らないと思うけど、 テスト中はリポジトリディレクトリにファイルを生成してしまうので ignore に追加した