### PR TITLE
feat: Make progress bar characters configurable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "simple-visual-bar-timer",
       "version": "0.0.1",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "18.x",
         "@types/vscode": "^1.74.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,16 @@
           "type": "number",
           "default": 25,
           "description": "The default duration for the timer in minutes."
+        },
+        "simpleVisualBarTimer.remainingChar": {
+          "type": "string",
+          "default": "▮",
+          "description": "The character representing the remaining time."
+        },
+        "simpleVisualBarTimer.elapsedChar": {
+          "type": "string",
+          "default": "▯",
+          "description": "The character representing the elapsed time."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,8 @@ export function activate(context: vscode.ExtensionContext) {
 
       const config = vscode.workspace.getConfiguration("simpleVisualBarTimer");
       const defaultDuration = config.get<number>("defaultDuration", 25);
+      const remainingChar = config.get<string>("remainingChar", "▮");
+      const elapsedChar = config.get<string>("elapsedChar", "▯");
 
       const durationInput = await vscode.window.showInputBox({
         prompt: "Enter timer duration in minutes (1-60)",
@@ -59,7 +61,8 @@ export function activate(context: vscode.ExtensionContext) {
 
           // カウントダウン式（残り時間が減るように見える）
           // const progressBar = "⭓".repeat(10 - progress) + "⭔".repeat(progress); // OK
-          const progressBar = "▮".repeat(10 - progress) + "▯".repeat(progress);
+          const progressBar =
+            remainingChar.repeat(10 - progress) + elapsedChar.repeat(progress);
 
           statusBarItem.text = `⦿ ${formattedTime} ${progressBar}`;
         };


### PR DESCRIPTION
Add two new configuration settings:
- `simpleVisualBarTimer.remainingChar`: The character for remaining time.
- `simpleVisualBarTimer.elapsedChar`: The character for elapsed time.

This allows users to customize the appearance of the progress bar.

fix: #13 ということ