### PR TITLE
feat: Make timer bar count configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ You can customize the timer by changing the following settings in your VS Code `
   - Default: `▮`
 - `simpleVisualBarTimer.elapsedChar`: The character used to represent the elapsed time in the progress bar.
   - Default: `▯`
+- `simpleVisualBarTimer.barCount`: The number of bars to display in the timer.
+  - Default: `10`
+  - Minimum: `5`
+  - Maximum: `30`
 
 ### Example Configuration
 
@@ -56,7 +60,8 @@ You can customize the timer by changing the following settings in your VS Code `
 {
   "simpleVisualBarTimer.defaultDuration": 10,
   "simpleVisualBarTimer.remainingChar": "⭓",
-  "simpleVisualBarTimer.elapsedChar": "⭔"
+  "simpleVisualBarTimer.elapsedChar": "⭔",
+  "simpleVisualBarTimer.barCount": 20
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,13 @@
           "type": "string",
           "default": "▯",
           "description": "The character representing the elapsed time."
+        },
+        "simpleVisualBarTimer.barCount": {
+          "type": "number",
+          "default": 10,
+          "minimum": 5,
+          "maximum": 30,
+          "description": "The number of bars to display in the timer."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,8 @@ export function activate(context: vscode.ExtensionContext) {
       const defaultDuration = config.get<number>("defaultDuration", 25);
       const remainingChar = config.get<string>("remainingChar", "▮");
       const elapsedChar = config.get<string>("elapsedChar", "▯");
+      let barCount = config.get<number>("barCount", 10);
+      barCount = Math.max(5, Math.min(30, barCount));
 
       const durationInput = await vscode.window.showInputBox({
         prompt: "Enter timer duration in minutes (1-60)",
@@ -51,10 +53,11 @@ export function activate(context: vscode.ExtensionContext) {
             .padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
 
           const progress = Math.floor(
-            ((totalSeconds - remainingSeconds) / totalSeconds) * 10
+            ((totalSeconds - remainingSeconds) / totalSeconds) * barCount
           );
           const progressBar =
-            remainingChar.repeat(10 - progress) + elapsedChar.repeat(progress);
+            remainingChar.repeat(barCount - progress) +
+            elapsedChar.repeat(progress);
 
           statusBarItem.text = `⦿ ${formattedTime} ${progressBar}`;
         };


### PR DESCRIPTION
Makes the number of timer bars configurable via a new setting, `simpleVisualBarTimer.barCount`.

- The number of bars can be set between 5 and 30.
- The default value is 10.
- Updated `package.json` with the new configuration setting.
- Updated `src/extension.ts` to use the configured value.
- Updated `README.md` to document the new setting.

fix: #12 ということ