### PR TITLE
fix: CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/* @officel
+* @officel


### PR DESCRIPTION
- #47
- reviewer の指定が発生しなかった
- `./github/` の下においておくとパス表記がダメ？
- または `/*` だとブロブがダメ？
- どうせ全部見るのは自分なら `*` でいいや。的な。