### PR TITLE
chore: bump 0.0.8

### DIFF
--- a/.config/.pymarkdown.yaml
+++ b/.config/.pymarkdown.yaml
@@ -20,6 +20,8 @@ plugins:
     enabled: false
   no-trailing-punctuation:
     enabled: false
+  no-duplicate-heading:
+    enabled: false
 extensions:
   front-matter:
     enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.0.8](https://github.com/officel/SVBT/compare/v0.0.7...v0.0.8) (2025-09-04)
+
+### Features
+
+- Variableize max duration and add tests ([#53](https://github.com/officel/SVBT/issues/53)) ([6939748](https://github.com/officel/SVBT/commit/6939748be4fc16901615fdcaf48100b4a254c432))
+- リポジトリにサポートファイル類を追加
+
+### Bug Fixes
+
+- CODEOWNERS ([#48](https://github.com/officel/SVBT/issues/48)) ([d4e29ff](https://github.com/officel/SVBT/commit/d4e29ffed2b781a687c58bc8e154df2648521e07)), closes [#47](https://github.com/officel/SVBT/issues/47)
+
 ## [0.0.7](https://github.com/officel/SVBT/compare/v0.0.2...v0.0.7) (2025-08-30)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-visual-bar-timer",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-visual-bar-timer",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "@vscode/vsce": "^3.6.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/officel/SVBT/issues"
   },
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "publisher": "officel",
   "icon": "resources/icon.png",


### PR DESCRIPTION
- 最大時間を 200 に変更
- OSS 系サポートファイルの追加
- 作業手順の見直し
- markdown lint から no-duplicate-heading を disable にした（バージョン毎に同じ名前のヘッダ出すし）