### PR TITLE
fix: Resolve ES module activation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "activationEvents": [
     "onStartupFinished"
   ],
-  "main": "./dist/extension.js",
+  "main": "./dist/extension.cjs",
   "contributes": {
     "commands": [
       {
@@ -99,7 +99,7 @@
     "glob": "^9.0.0"
   },
   "files": [
-    "dist/extension.js",
+    "dist/extension.cjs",
     "resources/icon.png",
     "package.json",
     "README.md",

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -11,7 +11,7 @@ const config = {
   output: {
     // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
     path: path.resolve(__dirname, "dist"),
-    filename: "extension.js",
+    filename: "extension.cjs",
     libraryTarget: "commonjs2",
     devtoolModuleFilenameTemplate: "../[resource-path]",
   },


### PR DESCRIPTION
The extension was failing to activate due to a module format mismatch. The `package.json` was configured with `"type": "module"`, causing the Node.js runtime to treat `.js` files as ES modules. However, the webpack build was producing a CommonJS bundle (`extension.js`).

This commit resolves the issue by renaming the output bundle to `extension.cjs`. This explicitly marks the file as a CommonJS module, aligning it with the output of the webpack build and resolving the "require is not defined" error during activation.

The following changes were made:
- `webpack.config.cjs`: Changed the output filename to `extension.cjs`.
- `package.json`: Updated the `main` and `files` fields to point to the new `extension.cjs` file.

失敗した。 v0.0.8 をリリースしたと思ったらエラーになって起動しなかった。。。
テストの手順と内容をもう一回整理しないと。