### PR TITLE
chore(dependabot): use groups setting on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # MEMO: 多数のプルリクエストを管理せずに済むように、メジャーバージョン以外のパッケージバージョンアップデートを単一の PR にまとめる。
+      # see https://dev.classmethod.jp/articles/dependabot-grouped-updates-isolating-specific-dependencies/
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
- dependabot がバラバラに PR を出してくるのが邪魔だなと思ったら Katsukiniwa が教えてくれた
- https://x.com/Katsukiniwa/status/1975467465082871914
- https://dev.classmethod.jp/articles/dependabot-grouped-updates-isolating-specific-dependencies/
- 流し見したせいで ignore してどうこうするのかと思ったらまとめて処理する方法は一番上だったｗ
- メジャーバージョンアップも含めて常に最新追従って感じにしたいんだけど、そもそも手動で更新しておけば必要ないかも
- とりあえずお手本のとおりの設定にしておいて様子をみようと思う